### PR TITLE
Added undocument, unexpeced values

### DIFF
--- a/models/orders-api-model/ordersV0.json
+++ b/models/orders-api-model/ordersV0.json
@@ -4368,7 +4368,10 @@
           "description": "The category of deemed reseller. This applies to selling partners that are not based in the EU and is used to help them meet the VAT Deemed Reseller tax laws in the EU and UK.",
           "enum": [
             "IOSS",
-            "UOSS"
+            "UOSS",
+            "CA_MPF",
+            "NZ_VOEC",
+            "AU_VOEC"
           ],
           "x-docgen-enum-table-extension": [
             {
@@ -4378,6 +4381,18 @@
             {
               "value": "UOSS",
               "description": "Union one stop shop. The item being purchased is held in the EU for shipment."
+            },
+            {
+              "value": "CA_MPF",
+              "description": "Undocumented, unexpected value."
+            },
+            {
+              "value": "NZ_VOEC",
+              "description": "Undocumented, unexpected value."
+            },
+            {
+              "value": "AU_VOEC",
+              "description": "Undocumented, unexpected value."
             }
           ]
         },


### PR DESCRIPTION
Added undocument, unexpeced values occuring in production for DeemedResellerCategory enum.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Fixes  [#2473](https://github.com/amzn/selling-partner-api-models/issues/2932)
